### PR TITLE
Fix for videos starting muted in Chrome

### DIFF
--- a/script.js
+++ b/script.js
@@ -88,6 +88,8 @@ function onMidi(player, data, time) {
     // NOTE OFF
     const note = hold(data[1], false);
     controls[note].classList.remove("pressed");
+    if (!Object.values(holding).includes(true))
+      player.pause();
 
   } else if (data.length === 3 && data[0] >> 4 === 9) {
     // NOTE ON

--- a/script.js
+++ b/script.js
@@ -62,11 +62,11 @@ function onResize(player) {
 }
 
 // It seems there's no explicit way to load a video,
-// so instead we mute the video and start playing it immediately.
+// so instead we start playing the video, then pause immediately
 // YouTube will lazily load the video as it plays.
 function startBuffering(player) {
-  player.mute();
   player.playVideo();
+  player.pauseVideo();
 }
 
 // Use the keyboard as a backup MIDI controller — GarageBand layout
@@ -88,15 +88,12 @@ function onMidi(player, data, time) {
     // NOTE OFF
     const note = hold(data[1], false);
     controls[note].classList.remove("pressed");
-    if (!Object.values(holding).includes(true))
-      player.mute();
 
   } else if (data.length === 3 && data[0] >> 4 === 9) {
     // NOTE ON
     const note = hold(data[1], true);
     controls[note].classList.add("pressed");
     player.seekTo(getValue(inputs[note]), true);
-    player.unMute();
     player.playVideo();
   }
 }


### PR DESCRIPTION
Instead of starting the video + muting it to begin buffering, start the video + pause it.